### PR TITLE
Release v1.0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 vim/bundle
 zsh/cache
 zsh/plugins
+zsh/.zsh_history
 irssi/logs
 ansible/tmp
 ssh/known_hosts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,6 @@ and this project adheres to [Romantic Versioning](http://dafoster.net/articles/2
 
 ### Changed
 - Changes in existing functionality
-- Moving to romaintic versioning scheme
-- Zsh environment related settings now confirmed into one file
-- Zsh history is only kept for non-privileged user accounts
-- Zsh alias for GNU tr instead of BSD tr
-- Zsh alias update! command is now a function and includes gem and pip updates
 
 ### Deprecated
 - Soon-to-be removed feature
@@ -28,6 +23,15 @@ and this project adheres to [Romantic Versioning](http://dafoster.net/articles/2
 
 ### Security
 - Fixed vulnerability
+
+
+## [v1.0.4] - 2018-10-14
+### Changed
+- Moving to romaintic versioning scheme
+- Zsh environment related settings now confirmed into one file
+- Zsh history is only kept for non-privileged user accounts
+- Zsh alias for GNU tr instead of BSD tr
+- Zsh alias update! command is now a function and includes gem and pip updates
 
 
 ## [v1.0.3] - 2018-09-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Romantic Versioning](http://dafoster.net/articles/2
 - Moving to romaintic versioning scheme
 - Zsh environment related settings now confirmed into one file
 - Zsh history is only kept for non-privileged user accounts
+- Zsh alias for GNU tr instead of BSD tr
 
 ### Deprecated
 - Soon-to-be removed feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Romantic Versioning](http://dafoster.net/articles/2
 - Zsh environment related settings now confirmed into one file
 - Zsh history is only kept for non-privileged user accounts
 - Zsh alias for GNU tr instead of BSD tr
+- Zsh alias update! command is now a function and includes gem and pip updates
 
 ### Deprecated
 - Soon-to-be removed feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Romantic Versioning](http://dafoster.net/articles/2
 - Changes in existing functionality
 - Moving to romaintic versioning scheme
 - Zsh environment related settings now confirmed into one file
+- Zsh history is only kept for non-privileged user accounts
 
 ### Deprecated
 - Soon-to-be removed feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+and this project adheres to [Romantic Versioning](http://dafoster.net/articles/2015/03/14/semantic-versioning-vs-romantic-versioning/).
 
 ## [Unreleased]
 ### Added
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Changes in existing functionality
+- Moving to romaintic versioning scheme
+- Zsh environment related settings now confirmed into one file
 
 ### Deprecated
 - Soon-to-be removed feature

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -14,6 +14,8 @@ alias egrep="egrep --color=auto"
 alias df='df -h'		# disk free, in Gigabytes, not bytes
 alias du='du -h -c'		# disk usage, for a folder
 
+alias tr='gtr'			# Use gnu tr
+
 # Diff
 alias diff='icdiff'
 

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -41,7 +41,16 @@ case `uname` in
 		alias mute="osascript -e 'set volume output muted true'"
 
 		# Update system
-		alias update!="brew update;brew upgrade;brew cleanup;brew doctor;brew cask upgrade;mas upgrade"
+		function update!() {
+			brew update
+			brew upgrade
+			brew cleanup
+			brew doctor
+			brew cask upgrade
+			mas upgrade
+			gem update
+			pip list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip install -U
+		} 
 
 		# todo.txt
 		# alias t=todo.sh

--- a/zsh/environment.zsh
+++ b/zsh/environment.zsh
@@ -1,0 +1,14 @@
+## Zsh Environment ##
+
+# Set default file permissions
+umask 022
+
+# Include Environment variables
+export PATH=$PATH:$HOME/.bin
+export EDITOR=vim
+
+# Fix language issue
+
+if [[ -z "$LC_ALL" ]]; then
+        export LC_ALL='en_US.UTF-8'
+fi

--- a/zsh/history.zsh
+++ b/zsh/history.zsh
@@ -2,4 +2,10 @@
 
 HISTSIZE=100000
 SAVEHIST=100000
-HISTFILE=~/.zsh_history
+HISTFILE=~/.zsh/.zsh_history
+
+# Don't keep history of root account
+if [ $UID = 0 ]; then
+  unset HISTFILE
+  SAVEHIST=0
+fi

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -1,11 +1,9 @@
 ##  Zsh general config ##
 
-
-
 # Include specialized configs
 
-source ~/.zsh/environment.zsh
-source ~/.zsh/history.zsh
+source ~/.zsh/environment.zsh		# Environment settings
+source ~/.zsh/history.zsh		# Keeping history settings
 
 source ~/.zsh/colors.zsh
 source ~/.zsh/setopts.zsh

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -1,19 +1,17 @@
 ##  Zsh general config ##
 
-# Fix language issue
 
-if [[ -z "$LC_ALL" ]]; then
-	export LC_ALL='en_US.UTF-8'
-fi
 
 # Include specialized configs
+
+source ~/.zsh/environment.zsh
+source ~/.zsh/history.zsh
 
 source ~/.zsh/colors.zsh
 source ~/.zsh/setopts.zsh
 source ~/.zsh/prompt.zsh
 source ~/.zsh/completion.zsh
 source ~/.zsh/aliases.zsh
-source ~/.zsh/history.zsh
 
 # Zsh Plugins
 


### PR DESCRIPTION
- Moving to romaintic versioning scheme
- Zsh environment related settings now confirmed into one file
- Zsh history is only kept for non-privileged user accounts
- Zsh alias for GNU tr instead of BSD tr
- Zsh alias update! command is now a function and includes gem and pip updates